### PR TITLE
layer-shell: set namespace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,7 @@ fn app_main(config: &Arc<AppConfig>, app: &Application) {
         Protocol::LayerShell => {
             window.init_layer_shell();
             window.set_layer(gtk_layer_shell::Layer::Overlay);
+            window.set_namespace("wleave");
             window.set_exclusive_zone(-1);
             window.set_keyboard_interactivity(true);
 


### PR DESCRIPTION
this sets namespace to `wleave` instead of generic (default) `gtk-layer-shell`

it is useful for compositors that can utilize it, e.g. [`Hyprland`](https://github.com/hyprwm/Hyprland), which has layer-rules based on layer name

mainly to distinguish from other apps that don't set namespace, and thus having multiple default `gtk-layer-shell`s

may be changed to smth more generic like `screenlock`, but i think it is ok to use appname, like e.g. [Waybar](https://github.com/Alexays/Waybar/)