### PR TITLE
label: add support for pango markup and justification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,7 @@ fn app_main(config: &Arc<AppConfig>, app: &Application) {
             "fill" => gtk::Justification::Fill,
             "left" => gtk::Justification::Left,
             "right" => gtk::Justification::Right,
-            _ => gtk::Justification::Center
+            _ => gtk::Justification::Center,
         };
 
         let button = gtk::Button::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,18 @@ struct WButton {
     action: String,
     text: String,
     keybind: String,
+    #[serde(default = "default_justify")]
+    justify: String,
     #[serde(default = "default_width")]
     width: f32,
     #[serde(default = "default_height")]
     height: f32,
     #[serde(default = "default_circular")]
     circular: bool,
+}
+
+fn default_justify() -> String {
+    String::from("center")
 }
 
 fn default_width() -> f32 {
@@ -230,6 +236,14 @@ fn app_main(config: &Arc<AppConfig>, app: &Application) {
             bttn.text.to_owned()
         };
 
+        let justify = match bttn.justify.as_str() {
+            "center" => gtk::Justification::Center,
+            "fill" => gtk::Justification::Fill,
+            "left" => gtk::Justification::Left,
+            "right" => gtk::Justification::Right,
+            _ => gtk::Justification::Center
+        };
+
         let button = gtk::Button::builder()
             .label(&label)
             .name(&bttn.label)
@@ -241,6 +255,8 @@ fn app_main(config: &Arc<AppConfig>, app: &Application) {
             if let Some(label) = label.downcast_ref::<Label>() {
                 label.set_xalign(bttn.width);
                 label.set_yalign(bttn.height);
+                label.set_use_markup(true);
+                label.set_justify(justify);
             }
         }
 


### PR DESCRIPTION
this adds ability to use [Pango markup](https://docs.gtk.org/Pango/pango_markup.html) in label text

also adds `justify` config key, defaulting to `center`
it aligns multi-line text in `label` container, the label itself still aligned with `width` and `height`

other options are:

- `fill`
- `right`
- `left`

font icons are rendered much better than **PNG** or **SVG**, besides, it is possible to add some `css` stuff to text like shadows

https://github.com/AMNatty/wleave/assets/130279855/d0d0211e-f128-4c34-972a-62d6400c000d

