### PR TITLE
docs: add `no-version-info` to example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ arguments.
     "delay-command-ms": 100,
     "close-on-lost-focus": true,
     "show-keybinds": true,
+    "no-version-info": true,
     "buttons": [
         {
             "label": "lock",


### PR DESCRIPTION
I didn't even know that was an option in the layout without manually checking `config.rs`