### PR TITLE
Support setting the button aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ From `man 5 wleave.json`, the allowed top-level options are:
 * `"margin-right"` **(number)** Set margin for right of buttons. Falls back to the value set by *margin*
 * `"margin-top"` **(number)** Set margin for top of buttons. Falls back to the value set by *margin*
 * `"margin-bottom"` **(number)** Set margin for bottom of buttons. Falls back to the value set by *margin*
+* `"button-aspect-ratio"` **(string or number)** Set the aspect ratio of the buttons, either as a float (as a number or
+  string) or a ratio (e.g. "5/4"). If unspecified, the buttons fill all available space between the margins.
 * `"close-on-lost-focus": false` **(boolean)** Closes the menu if focus is lost
 * `"show-keybinds": false`: **(boolean)** Show the associated key binds for each button
 * `"protocol": "layer-shell"` (**"layer-shell"**/**"xdg"**) Backend to use for full-screening the menu

--- a/completions/_wleave
+++ b/completions/_wleave
@@ -35,6 +35,8 @@ _wleave() {
 '--margin-top=[Set margin for the top of buttons]:MARGIN_TOP:_default' \
 '-B+[Set the margin for the bottom of buttons]:MARGIN_BOTTOM:_default' \
 '--margin-bottom=[Set the margin for the bottom of buttons]:MARGIN_BOTTOM:_default' \
+'-A+[Set the aspect ratio of the buttons]:BUTTON_ASPECT_RATIO:_default' \
+'--button-aspect-ratio=[Set the aspect ratio of the buttons]:BUTTON_ASPECT_RATIO:_default' \
 '-d+[The delay (in milliseconds) between the window closing and executing the selected option]:DELAY_COMMAND_MS:_default' \
 '--delay-command-ms=[The delay (in milliseconds) between the window closing and executing the selected option]:DELAY_COMMAND_MS:_default' \
 '-f+[Close the menu on lost focus]' \

--- a/completions/wleave.bash
+++ b/completions/wleave.bash
@@ -23,7 +23,7 @@ _wleave() {
 
     case "${cmd}" in
         wleave)
-            opts="-v -l -C -b -c -r -m -L -R -T -B -d -f -k -p -x -h --version --layout --css --buttons-per-row --column-spacing --row-spacing --margin --margin-left --margin-right --margin-top --margin-bottom --delay-command-ms --close-on-lost-focus --show-keybinds --protocol --no-version-info --help"
+            opts="-v -l -C -b -c -r -m -L -R -T -B -A -d -f -k -p -x -h --version --layout --css --buttons-per-row --column-spacing --row-spacing --margin --margin-left --margin-right --margin-top --margin-bottom --button-aspect-ratio --delay-command-ms --close-on-lost-focus --show-keybinds --protocol --no-version-info --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -106,6 +106,14 @@ _wleave() {
                     return 0
                     ;;
                 -B)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --button-aspect-ratio)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -A)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/wleave.fish
+++ b/completions/wleave.fish
@@ -8,6 +8,7 @@ complete -c wleave -s L -l margin-left -d 'Set margin for the left of buttons' -
 complete -c wleave -s R -l margin-right -d 'Set margin for the right of buttons' -r
 complete -c wleave -s T -l margin-top -d 'Set margin for the top of buttons' -r
 complete -c wleave -s B -l margin-bottom -d 'Set the margin for the bottom of buttons' -r
+complete -c wleave -s A -l button-aspect-ratio -d 'Set the aspect ratio of the buttons' -r
 complete -c wleave -s d -l delay-command-ms -d 'The delay (in milliseconds) between the window closing and executing the selected option' -r
 complete -c wleave -s f -l close-on-lost-focus -d 'Close the menu on lost focus' -r -f -a "true\t''
 false\t''"

--- a/man/wleave.1.scd
+++ b/man/wleave.1.scd
@@ -46,6 +46,10 @@ wleave - A Wayland logout menu
 *-B, --margin-bottom* <padding>
 	Set margin for bottom of buttons
 
+*-A, --button-aspect-ratio* <ratio>
+	Set the aspect ratio of the buttons, either as a float (as a number or string) or a ratio (e.g. "5/4").
+	If unspecified, the buttons fill all available space between the margins.
+
 *-f, --close-on-lost-focus*
 	Closes the menu if focus is lost
 

--- a/man/wleave.json.5.scd
+++ b/man/wleave.json.5.scd
@@ -48,6 +48,10 @@ Falls back to the value set by *margin*
 	Set margin for bottom of buttons ++
 Falls back to the value set by *margin*
 
+*"button-aspect-ratio"* <string or number>
+	Set the aspect ratio of the buttons, either as a float (as a number or string) or a ratio (e.g. "5/4"). ++
+If unspecified, the buttons fill all available space between the margins.
+
 *"close-on-lost-focus"*: <*true*/*false*>
 	Closes the menu if focus is lost ++
 *Default*: false

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use tracing::{Level, debug, enabled, error, info, warn};
-use wleave::cli_opt::{Args, ButtonLayout, Protocol};
+use wleave::cli_opt::{Args, AspectRatio, ButtonLayout, Protocol};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -23,6 +23,7 @@ pub struct AppConfig {
     pub column_spacing: u32,
     #[serde(default = "default_spacing")]
     pub row_spacing: u32,
+    pub button_aspect_ratio: Option<AspectRatio>,
     #[serde(default = "default_delay")]
     pub delay_command_ms: u32,
     #[serde(default)]
@@ -49,6 +50,7 @@ impl Default for AppConfig {
             margin: default_margin(),
             column_spacing: default_spacing(),
             row_spacing: default_spacing(),
+            button_aspect_ratio: None,
             delay_command_ms: default_delay(),
             protocol: Default::default(),
             buttons_per_row: Default::default(),
@@ -261,6 +263,19 @@ pub fn merge_with_args(config: &mut AppConfig, args: &Args) {
         info!(
             "\"row-spacing\" specified from config: {}",
             config.row_spacing
+        );
+    }
+
+    if let Some(aspect_ratio) = args.button_aspect_ratio {
+        info!(
+            "\"button-aspect-ratio\" specified from args: {}",
+            aspect_ratio
+        );
+        config.button_aspect_ratio = Some(aspect_ratio);
+    } else {
+        info!(
+            "\"button-aspect-ratio\" specified from config: {:?}",
+            config.button_aspect_ratio
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,7 @@ fn app_main(config: &Arc<AppConfig>, app: &libadwaita::Application) {
         grid.attach(&button, x as i32, y as i32, 1, 1);
     }
 
-    container_box.insert_child_after(&grid, Option::<&gtk4::Widget>::None);
+    container_box.append(&grid);
 
     if !config.no_version_info {
         let version_info = gtk4::Label::builder()
@@ -283,7 +283,7 @@ fn app_main(config: &Arc<AppConfig>, app: &libadwaita::Application) {
         .css_classes(["dimmed", "version-info"])
         .margin_top(12)
         .build();
-        container_box.insert_child_after(&version_info, Some(&grid));
+        container_box.append(&version_info);
     }
 
     window.present();

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,6 @@ fn app_main(config: &Arc<AppConfig>, app: &libadwaita::Application) {
     let window = ApplicationWindow::builder()
         .application(app)
         .title("wleave")
-        .child(&container_box)
         .build();
 
     match config.protocol {
@@ -170,7 +169,10 @@ fn app_main(config: &Arc<AppConfig>, app: &libadwaita::Application) {
     window.add_controller(key_controller);
 
     let grid = gtk4::Grid::new();
+    grid.set_column_homogeneous(true);
+    grid.set_row_homogeneous(true);
     grid.set_column_spacing(config.column_spacing);
+    grid.set_vexpand(true);
     grid.set_row_spacing(config.row_spacing);
 
     let btn_count = config.buttons.len() as u32;
@@ -178,6 +180,20 @@ fn app_main(config: &Arc<AppConfig>, app: &libadwaita::Application) {
         ButtonLayout::PerRow(n) => n,
         ButtonLayout::RowRatio(n, d) => btn_count * n / d.min(btn_count * n),
     };
+
+    if let Some(ratio) = config.button_aspect_ratio {
+        let rows = btn_count.div_ceil(buttons_per_row);
+        let frame = gtk4::AspectFrame::builder()
+            .ratio(ratio.as_float() * (buttons_per_row as f32) / (rows as f32))
+            .hexpand(true)
+            .vexpand(true)
+            .obey_child(false)
+            .child(&container_box)
+            .build();
+        window.set_child(Some(&frame));
+    } else {
+        window.set_child(Some(&container_box));
+    }
 
     for (i, bttn) in config.buttons.iter().enumerate() {
         let justify = match bttn.justify.as_str() {


### PR DESCRIPTION
This looks better when the aspect ratio of the grid is very different from the aspect ratio of the monitor (resulting in very tall or very wide buttons). This is not always avoidable by using a button layout that fits the monitor (for example, when using multiple monitors with very different aspect ratios).

On one of my monitors without this patch:

<img width="2560" height="2880" alt="tall" src="https://github.com/user-attachments/assets/05450879-e3a7-450a-aa77-7ed758c8321e" />

With this patch and `--button-aspect-ratio 1`:

<img width="2560" height="2880" alt="fixed" src="https://github.com/user-attachments/assets/fe2fa890-67e9-431d-92a0-045cb859554c" />

...and I can't just use a more square button arrangement because I have a "normal" 16:9 monitor sitting next to it, where this 2x4 grid makes sense.

This is a draft because of two issues:

- The version info can end up far removed from the buttons:

<img width="2560" height="2880" alt="fixed-with-version" src="https://github.com/user-attachments/assets/e99d7407-7d48-49ff-995a-cee6ca64d7e8" />

I haven't figured out a way of fixing this yet (but I also haven't wrapped my head around how Gtk layout actually works yet, so it might well be easy, hints appreciated!). If I don't allow the grid and/or buttons to consume extra space, everything shrinks to the size of the icons in the buttons... (the buttons get much smaller).

- Specifying the ratio as a float is maybe not the best (it should maybe be a fraction like how buttons-per-row works?)

Any feedback much appreciated.