### PR TITLE
Fixed the desktop file

### DIFF
--- a/sh.natty.Wleave.desktop
+++ b/sh.natty.Wleave.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
-Version=0.7.2
+# The version of the Desktop Entry spec, not of the application:
+Version=1.0
 Type=Application
 Name=Wleave
 Comment=Open a system log-out menu
@@ -7,4 +8,4 @@ Icon=wleave
 Exec=wleave
 Terminal=false
 StartupNotify=false
-Categories=Application;
+Categories=System;


### PR DESCRIPTION
I've been trying to create an RPM of wleave to replace the seemingly abandoned wlogout but installing the desktop file causes building the RPM to fail due to errors given by `desktop-file-validate`. This makes the desktop file valid.