### PR TITLE
CSS priority and initial focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ From `man 5 wleave.json`, the allowed top-level options are:
   cost of running in the background
 * `"button-layout": "grid"` Specify the way buttons should be laid out.
   See [dynamic layouts](#dynamic-layouts-supsince-070sup) for more details.
+* `"default-button"` **(string)** - Specify the label of the button to focus by default
 * `"buttons-per-row": "3"` **(string)** Set the number of buttons per row, or use a fraction to specify the number
   of rows to be used (e.g. "1/1" for all buttons in a single row, "1/5" to distribute the buttons over 5 rows)
 * `"column-spacing": "8px"` **(number / "#px" / "#%")** Set space between buttons columns
@@ -95,6 +96,7 @@ The command-line option counterparts of these options take precedence over the c
     "delay-command-ms": 100,
     "close-on-lost-focus": true,
     "show-keybinds": true,
+    "default-button": "lock",
     "buttons": [
         {
             "label": "lock",

--- a/completions/_wleave
+++ b/completions/_wleave
@@ -20,6 +20,8 @@ _wleave() {
 '-l+[Specify a layout file, specifying - will read the layout config from stdin]:LAYOUT:_files' \
 '--layout=[Specify a layout file, specifying - will read the layout config from stdin]:LAYOUT:_files' \
 '--button-layout=[Specify the way the buttons should be laid out in the available space]:BUTTON_LAYOUT:(grid)' \
+'-D+[Specify the default button to focus]:DEFAULT_BUTTON:_default' \
+'--default-button=[Specify the default button to focus]:DEFAULT_BUTTON:_default' \
 '-C+[Specify a custom CSS file]:CSS:_files' \
 '--css=[Specify a custom CSS file]:CSS:_files' \
 '-b+[Set the number of buttons per row, or use a fraction to specify the number of rows to be used (e.g. "1/1" for all buttons in a single row, "1/5" to distribute the buttons over 5 rows)]:BUTTONS_PER_ROW:_default' \

--- a/completions/wleave.bash
+++ b/completions/wleave.bash
@@ -23,7 +23,7 @@ _wleave() {
 
     case "${cmd}" in
         wleave)
-            opts="-v -s -l -C -b -c -r -m -L -R -T -B -A -d -f -k -p -x -h --version --service --layout --button-layout --css --buttons-per-row --column-spacing --row-spacing --margin --margin-left --margin-right --margin-top --margin-bottom --button-aspect-ratio --delay-command-ms --close-on-lost-focus --show-keybinds --protocol --no-version-info --help"
+            opts="-v -s -l -D -C -b -c -r -m -L -R -T -B -A -d -f -k -p -x -h --version --service --layout --button-layout --default-button --css --buttons-per-row --column-spacing --row-spacing --margin --margin-left --margin-right --margin-top --margin-bottom --button-aspect-ratio --delay-command-ms --close-on-lost-focus --show-keybinds --protocol --no-version-info --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -47,6 +47,14 @@ _wleave() {
                     ;;
                 --button-layout)
                     COMPREPLY=($(compgen -W "grid" -- "${cur}"))
+                    return 0
+                    ;;
+                --default-button)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -D)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --css)

--- a/completions/wleave.fish
+++ b/completions/wleave.fish
@@ -2,6 +2,7 @@ complete -c wleave -s s -l service -d 'Run the application in service mode - it 
 false\t''"
 complete -c wleave -s l -l layout -d 'Specify a layout file, specifying - will read the layout config from stdin' -r -F
 complete -c wleave -l button-layout -d 'Specify the way the buttons should be laid out in the available space' -r -f -a "grid\t''"
+complete -c wleave -s D -l default-button -d 'Specify the default button to focus' -r
 complete -c wleave -s C -l css -d 'Specify a custom CSS file' -r -F
 complete -c wleave -s b -l buttons-per-row -d 'Set the number of buttons per row, or use a fraction to specify the number of rows to be used (e.g. "1/1" for all buttons in a single row, "1/5" to distribute the buttons over 5 rows)' -r
 complete -c wleave -s c -l column-spacing -d 'Set space between buttons columns' -r

--- a/man/wleave.1.scd
+++ b/man/wleave.1.scd
@@ -18,6 +18,9 @@ wleave - A Wayland logout menu
 
 *--button-layout* "grid"
 	Specify the way buttons should be laid out, "grid" being the default. Currently, only "grid" is supported.
+	
+*-D, --default-button* <button_label>
+	Specify the label of the button to focus by default
 
 *-S, --service*
 	Run the application as a service, with all instances of wleave opening this one. Allows faster startup at the cost of running in the background.

--- a/man/wleave.json.5.scd
+++ b/man/wleave.json.5.scd
@@ -15,6 +15,9 @@ Button layout is specified in the extra *"button"* field.
 *"button-layout"*: <*"grid"*>
 	Specify the way buttons should be laid out, "grid" being the default. Currently, only "grid" is supported.
 
+*"default-button"*: <string>
+    Specify the label of the button to focus by default
+
 *"css"*: <string>
 	Specify a custom CSS file instead of the default one
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -276,7 +276,7 @@ pub fn create_app(config: &Arc<AppConfig>, app: &libadwaita::Application) -> Wle
         if config.default_button.as_ref() == Some(&bttn.label) {
             default_button = Some(button.clone());
         }
-        
+
         let overlay = gtk4::Overlay::builder().vexpand(true).hexpand(true).build();
 
         if config.show_keybinds {
@@ -353,7 +353,7 @@ pub fn create_app(config: &Arc<AppConfig>, app: &libadwaita::Application) -> Wle
 
     if let Some(btn) = default_button {
         btn.grab_focus();
-    } else{
+    } else {
         let window = window.clone();
         glib::idle_add_local_once(move || {
             window.set_focus(None::<&gtk4::Widget>);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -257,6 +257,7 @@ pub fn create_app(config: &Arc<AppConfig>, app: &libadwaita::Application) -> Wle
         ))
         .build();
 
+    let mut default_button = None;
     for bttn in config.buttons.iter() {
         let justify = match bttn.justify {
             WButtonJustify::Center => gtk4::Justification::Center,
@@ -272,6 +273,10 @@ pub fn create_app(config: &Arc<AppConfig>, app: &libadwaita::Application) -> Wle
             .cursor(&gdk4::Cursor::from_name("pointer", None).expect("pointer cursor not found"))
             .build();
 
+        if config.default_button.as_ref() == Some(&bttn.label) {
+            default_button = Some(button.clone());
+        }
+        
         let overlay = gtk4::Overlay::builder().vexpand(true).hexpand(true).build();
 
         if config.show_keybinds {
@@ -343,9 +348,17 @@ pub fn create_app(config: &Arc<AppConfig>, app: &libadwaita::Application) -> Wle
 
         buttons_container.append(&button);
     }
-
     container_box.set_shrink_center_last(false);
     container_box.set_center_widget(Some(&buttons_container));
+
+    if let Some(btn) = default_button {
+        btn.grab_focus();
+    } else{
+        let window = window.clone();
+        glib::idle_add_local_once(move || {
+            window.set_focus(None::<&gtk4::Widget>);
+        });
+    }
 
     if !config.no_version_info {
         let version_info = gtk4::Label::builder()

--- a/src/cli_opt.rs
+++ b/src/cli_opt.rs
@@ -44,6 +44,10 @@ pub struct Args {
     #[arg(long)]
     pub button_layout: Option<MenuLayoutStrategy>,
 
+    /// Specify the label of the button to focus by default
+    #[arg(short = 'D', long)]
+    pub default_button: Option<String>,
+
     /// Specify a custom CSS file
     #[arg(short = 'C', long)]
     pub css: Option<PathBuf>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct AppConfig {
     pub service: bool,
     #[serde(default)]
     pub button_layout: MenuLayoutStrategy,
+    pub default_button: Option<String>,
     pub margin_left: Option<Margin>,
     pub margin_right: Option<Margin>,
     pub margin_top: Option<Margin>,
@@ -51,6 +52,7 @@ impl Default for AppConfig {
         AppConfig {
             service: false,
             button_layout: MenuLayoutStrategy::Grid,
+            default_button: None,
             margin_left: None,
             margin_right: None,
             margin_top: None,
@@ -224,6 +226,7 @@ macro_rules! merge_option {
 pub fn merge_with_args(config: &mut AppConfig, args: Args) {
     merge_option!(config, args, service);
     merge_option!(config, args, button_layout);
+    merge_option!(config, args, default_button => Some(default_button));
     merge_option!(config, args, margin_top => Some(margin_top));
     merge_option!(config, args, margin_bottom => Some(margin_bottom));
     merge_option!(config, args, margin_left => Some(margin_left));

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn on_startup(config: &AppConfig) {
         Ok(css) => gtk4::style_context_add_provider_for_display(
             &display,
             &css,
-            gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+            gtk4::STYLE_PROVIDER_PRIORITY_USER+1,
         ),
         Err(e) => error!("Failed to load CSS: {e}"),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn on_startup(config: &AppConfig) {
         Ok(css) => gtk4::style_context_add_provider_for_display(
             &display,
             &css,
-            gtk4::STYLE_PROVIDER_PRIORITY_USER+1,
+            gtk4::STYLE_PROVIDER_PRIORITY_USER + 1,
         ),
         Err(e) => error!("Failed to load CSS: {e}"),
     };


### PR DESCRIPTION
This PR:

* Fixes CSS provider priority so application styles are applied in this order.
 1.  `~/.config/wleave/style.css`
 2. `~/.config/gtk-4.0/gtk.css`

* Adds an option to select which button receives focus on startup.